### PR TITLE
Improved ContinuousBuzzer and mem usage

### DIFF
--- a/src/main/java/net/mabboud/android_tone_player/ContinuousBuzzer.java
+++ b/src/main/java/net/mabboud/android_tone_player/ContinuousBuzzer.java
@@ -36,13 +36,14 @@ public class ContinuousBuzzer extends TonePlayer{
         this.pausePeriodSeconds = pausePeriodSeconds;
     }
 
-    protected void asyncPlayTrack(final double toneFreqInHz) {
+    protected void asyncPlayTrack() {
         playerWorker = new Thread(new Runnable() {
             public void run() {
                 while (isPlaying) {
                     // will pause every x seconds useful for determining when a certain amount
                     // of time has passed while whatever the buzzer is signaling is active
-                    playTone(toneFreqInHz, pausePeriodSeconds);
+                             // (if pause time not increased then continuous tone)
+                    playTone(pausePeriodSeconds, (pauseTimeInMs <= 1));
                     try {
                         Thread.sleep(pauseTimeInMs);
                     } catch (InterruptedException e) {

--- a/src/main/java/net/mabboud/android_tone_player/OneTimeBuzzer.java
+++ b/src/main/java/net/mabboud/android_tone_player/OneTimeBuzzer.java
@@ -22,10 +22,11 @@ public class OneTimeBuzzer extends TonePlayer {
         this.duration = duration;
     }
 
-    protected void asyncPlayTrack(final double toneFreqInHz) {
+    protected void asyncPlayTrack() {
         playerWorker = new Thread(new Runnable() {
             public void run() {
-                playTone(toneFreqInHz, duration);
+                playTone(duration);
+                stop();                //stop after sound played (one time)
             }
         });
 


### PR DESCRIPTION
Thanks for posting the tone-player code; it helped me a lot.

For [my ArduVidRx project](http://www.etheli.com/ArduVidRx) I'm looking to play a continuous tone, with the tone varying in real time in proportion to an input signal (RSSI).  I've modified the ContinuousBuzzer so it can do this, and made it so the sample arrays and AudioTrack object are reused as much as possible.  The played tone is not as clean as I'd like (has small glitches), but it can now be played while changing the frequency in real time.

If anyone has a way to clean up the small glitches, please chime in.

--ET